### PR TITLE
Created Node::getLogicalBlock().

### DIFF
--- a/src/Node.php
+++ b/src/Node.php
@@ -413,6 +413,19 @@ abstract class Node implements NodeInterface {
     return $path;
   }
 
+  /**
+   * Returns the code block containing this node. The code block could be a
+   * control structure (if statement, for loop, case statement, etc.), a
+   * function, a class definition, or the whole syntax tree.
+   *
+   * @return StatementBlockNode|TopNode|NULL
+   */
+  public function getLogicalBlock() {
+    return $this->closest(function(Node $node) {
+      return $node instanceof StatementBlockNode || $node instanceof TopNode;
+    });
+  }
+
   public function __clone() {
     // Clone does not belong to any parent.
     $this->parent = NULL;


### PR DESCRIPTION
Here's a convenience method on Node (because it's a convenience method, I didn't bother to add it to NodeInterface) which will return the closest StatementBlockNode or TopNode, which as far as I can tell should cover just about any context which could be a code block (if, elseif, else, do/while, for, case, class, function, top level...did I miss any?)

From issue #15.
