### PR TITLE
Added a basic filter for scalar constants. (#38)

### DIFF
--- a/src/Filter.php
+++ b/src/Filter.php
@@ -90,6 +90,17 @@ class Filter {
       return FALSE;
     };
   }
+  
+  /**
+   * Filters on scalar constants (strings and numbers).
+   *
+   * @todo Support boolean constants, NULL constant, and scalar expressions.
+   *
+   * @return boolean
+   */
+  public static function isScalar(Node $node) {
+    return $node instanceof StringNode || $node instanceof IntegerNode || $node instanceof FloatNode;
+  }
 
   /**
    * Callback to filter for calls to a class method.


### PR DESCRIPTION
This is a basic static filter for finding scalar constants (currently constant strings and numbers), like so:

``` php
$myNode->find('Pharborist\Filter::isScalar')
```
