### PR TITLE
Made Filter::isInstanceOf accept multiple class names. (#62)

### DIFF
--- a/src/Filter.php
+++ b/src/Filter.php
@@ -44,8 +44,15 @@ class Filter {
    * @return callable
    */
   public static function isInstanceOf($class_name) {
-    return function ($node) use ($class_name) {
-      return $node instanceof $class_name;
+    $classes = func_get_args();
+
+    return function ($node) use ($classes) {
+      foreach ($classes as $class) {
+        if ($node instanceof $class) {
+          return TRUE;
+        }
+      }
+      return FALSE;
     };
   }
 


### PR DESCRIPTION
This patch makes Filter::isInstanceOf variadic so that it can accept multiple class names. It will return TRUE if the node is any of them.

``` php
$tree->children(Filter::isInstanceOf('Pharborist\ClassNode', 'Pharborist\FunctionDeclarationNode', 'Pharborist\ImportNode'))
```
