### PR TITLE
Created Node::fromScalar(). (#80)

### DIFF
--- a/src/BooleanNode.php
+++ b/src/BooleanNode.php
@@ -14,12 +14,11 @@ abstract class BooleanNode extends ConstantNode {
    * @return BooleanNode
    */
   public static function create($boolean) {
-    $is_upper = Settings::get('formatter.boolean_null.upper', TRUE);
     if ($boolean) {
-      return ConstantNode::create($is_upper ? 'TRUE' : 'true');
+      return TrueNode::create();
     }
     else {
-      return ConstantNode::create($is_upper ? 'FALSE' : 'false');
+      return FalseNode::create();
     }
   }
 

--- a/src/ConstantNode.php
+++ b/src/ConstantNode.php
@@ -17,7 +17,8 @@ class ConstantNode extends ParentNode implements ExpressionNode {
     if (is_string($name)) {
       $name = NameNode::create($name);
     }
-    $node = new ConstantNode();
+    /** @var ConstantNode $node */
+    $node = new static();
     $node->addChild($name, 'constantName');
     return $node;
   }

--- a/src/FalseNode.php
+++ b/src/FalseNode.php
@@ -9,7 +9,10 @@ class FalseNode extends BooleanNode {
    * @return FalseNode
    */
   public static function create($boolean = FALSE) {
-    return BooleanNode::create(FALSE);
+    $is_upper = Settings::get('formatter.boolean_null.upper', TRUE);
+    $node = new FalseNode();
+    $node->addChild(NameNode::create($is_upper ? 'FALSE' : 'false'), 'constantName');
+    return $node;
   }
 
   public function toBoolean() {

--- a/src/Node.php
+++ b/src/Node.php
@@ -507,7 +507,7 @@ abstract class Node implements NodeInterface {
    */
   public static function fromScalar($value) {
     if (is_string($value)) {
-      return new StringNode(T_STRING, $value);
+      return new StringNode(T_STRING, var_export($value, TRUE));
     }
     elseif (is_integer($value)) {
       return new IntegerNode(T_LNUMBER, $value);

--- a/src/NullNode.php
+++ b/src/NullNode.php
@@ -10,6 +10,8 @@ class NullNode extends ConstantNode {
    */
   public static function create($name = 'null') {
     $is_upper = Settings::get('formatter.boolean_null.upper', TRUE);
-    return ConstantNode::create($is_upper ? 'NULL' : 'null');
+    $node = new NullNode();
+    $node->addChild(NameNode::create($is_upper ? 'NULL' : 'null'), 'constantName');
+    return $node;
   }
 }

--- a/src/StringNode.php
+++ b/src/StringNode.php
@@ -19,20 +19,6 @@ class StringNode extends TokenNode implements ExpressionNode {
     return new StringNode(T_CONSTANT_ENCAPSED_STRING, $text);
   }
 
-  public function setText($value) {
-    // If $value is already quoted, no need to do anything.
-    if (!preg_match('#^(\'|").+\1$#', $value)) {
-      // If $value contains an unescaped variable, use double quotes.
-      if (preg_match('/[^\\\\]\$/', $value)) {
-        $value = '"' . $value . '"';
-      }
-      else {
-        $value = "'$value'";
-      }
-    }
-    return parent::setText($value);
-  }
-
   /**
    * Returns the original value of the string (unenclosed by quotes).
    *

--- a/src/TrueNode.php
+++ b/src/TrueNode.php
@@ -9,7 +9,10 @@ class TrueNode extends BooleanNode {
    * @return TrueNode
    */
   public static function create($boolean = TRUE) {
-    return BooleanNode::create(TRUE);
+    $is_upper = Settings::get('formatter.boolean_null.upper', TRUE);
+    $node = new TrueNode();
+    $node->addChild(NameNode::create($is_upper ? 'TRUE' : 'true'), 'constantName');
+    return $node;
   }
 
   public function toBoolean() {

--- a/tests/NodeTest.php
+++ b/tests/NodeTest.php
@@ -415,14 +415,14 @@ class NodeTest extends \PHPUnit_Framework_TestCase {
     $this->assertEquals("'foobar'", $string->getText());
 
     $string = Node::fromScalar("'foobaz'");
-    $this->assertEquals("'foobaz'", $string->getText());
+    $this->assertEquals("'\\'foobaz\\''", $string->getText());
 
     $string = Node::fromScalar('Hi, $foobaz');
     $this->assertInstanceOf('\Pharborist\StringNode', $string);
-    $this->assertEquals('"Hi, $foobaz"', $string->getText());
+    $this->assertEquals("'Hi, \$foobaz'", $string->getText());
 
     $string = Node::fromScalar('"Yippee ki-yay, $buddeh!"');
-    $this->assertEquals('"Yippee ki-yay, $buddeh!"', $string->getText());
+    $this->assertEquals("'\"Yippee ki-yay, \$buddeh!\"'", $string->getText());
 
     $integer = Node::fromScalar(30);
     $this->assertInstanceOf('\Pharborist\IntegerNode', $integer);
@@ -439,8 +439,8 @@ class NodeTest extends \PHPUnit_Framework_TestCase {
 
     $false = Node::fromScalar(FALSE);
     $this->assertInstanceOf('\Pharborist\FalseNode', $false);
-    $this->assertSame(TRUE, $false->toBoolean());
-    $this->assertEquals('TRUE', $false->getText());
+    $this->assertSame(FALSE, $false->toBoolean());
+    $this->assertEquals('FALSE', $false->getText());
 
     $null = Node::fromScalar(NULL);
     $this->assertInstanceOf('\Pharborist\NullNode', $null);


### PR DESCRIPTION
Added a method to create a new StringNode, FloatNode, or IntegerNode from a scalar. I had to override setText() in StringNode to account for quoting. I wrote some tests, and it passes, but the quoting stuff was a bit hairy and I don't know the PHP grammar anywhere near as well as you do, so I dunno if this will pass muster. Nevertheless...
