### PR TITLE
setVisibility() can accept visibility constants or strings

### DIFF
--- a/src/VisibilityTrait.php
+++ b/src/VisibilityTrait.php
@@ -26,6 +26,16 @@ trait VisibilityTrait {
       $this->visibility->remove();
     }
     else {
+      if ($visibility === 'private' || $visibility === T_PRIVATE) {
+        $visibility = Token::_private();
+      }
+      elseif ($visibility === 'protected' || $visibility === T_PROTECTED) {
+        $visibility = Token::_protected();
+      }
+      elseif ($visibility === 'public' || $visibility === T_PUBLIC) {
+        $visibility = Token::_public();
+      }
+
       if (isset($this->visibility)) {
         $this->visibility->replaceWith($visibility);
       }

--- a/tests/VisibilityTraitTest.php
+++ b/tests/VisibilityTraitTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Pharborist;
+
+class VisibilityTraitTest extends \PHPUnit_Framework_TestCase {
+  public function testSetVisibility() {
+    $method = Parser::parseSnippet('class Foo { public function wrassle() {} }')->getBody()->firstChild();
+
+    $method->setVisibility('private');
+    $this->assertStringStartsWith('private', $method->getText());
+
+    $method->setVisibility('protected');
+    $this->assertStringStartsWith('protected', $method->getText());
+
+    $method->setVisibility('public');
+    $this->assertStringStartsWith('public', $method->getText());
+
+    $method->setVisibility(NULL);
+    $this->assertStringStartsWith('function', $method->getText());
+
+    $method->setVisibility(T_PRIVATE);
+    $this->assertStringStartsWith('private', $method->getText());
+
+    $method->setVisibility(T_PROTECTED);
+    $this->assertStringStartsWith('protected', $method->getText());
+
+    $method->setVisibility(T_PUBLIC);
+    $this->assertStringStartsWith('public', $method->getText());
+
+    $method->setVisibility(Token::_private());
+    $this->assertStringStartsWith('private', $method->getText());
+
+    $method->setVisibility(Token::_protected());
+    $this->assertStringStartsWith('protected', $method->getText());
+
+    $method->setVisibility(Token::_public());
+    $this->assertStringStartsWith('public', $method->getText());
+  }
+}


### PR DESCRIPTION
This patch (with tests accourse) allows VisiblityTrait::setVisibility() to accept the strings 'private', 'public', or 'protected', or the constants T_PRIVATE, T_PUBLIC, T_PROTECTED...or an existing TokenNode.
