### PR TITLE
FunctionDeclarationNode::cloneAsMethodOf()

### DIFF
--- a/src/ClassMethodNode.php
+++ b/src/ClassMethodNode.php
@@ -50,9 +50,12 @@ class ClassMethodNode extends ClassStatementNode {
     // converted a function into a method we also wish to indent the closing
     // brace, so get the last whitespace node and add an indent to it.
     /** @var WhitespaceNode $ws_node */
-    $ws_node = $method->getBody()->children(Filter::isInstanceOf('\Pharborist\WhitespaceNode'))->last()[0];
-    $text = $ws_node->getText();
-    $ws_node->setText($text . Settings::get('formatter.indent'));
+    $ws = $method->getBody()->children(Filter::isInstanceOf('\Pharborist\WhitespaceNode'));
+    if ($ws->count() > 0) {
+      $ws_node = $ws->last()[0];
+      $text = $ws_node->getText();
+      $ws_node->setText($text . Settings::get('formatter.indent'));
+    }
     return $method;
   }
 

--- a/src/FunctionDeclarationNode.php
+++ b/src/FunctionDeclarationNode.php
@@ -57,6 +57,22 @@ class FunctionDeclarationNode extends StatementNode {
     return $this->body;
   }
 
+  /**
+   * Creates a class method from this function and add it to the given
+   * class definition.
+   *
+   * @param \Pharborist\ClassNode $class
+   *  The class to add the new method to.
+   *
+   * @return \Pharborist\ClassMethodNode
+   *  The newly created method.
+   */
+  public function cloneAsMethodOf(ClassNode $class) {
+    $clone = ClassMethodNode::fromFunction($this);
+    $class->appendMethod($clone);
+    return $clone;
+  }
+
   protected function childInserted(Node $node) {
     if ($node instanceof TokenNode && $node->getType() === '&') {
       $this->reference = $node;

--- a/tests/FunctionDeclarationNodeTest.php
+++ b/tests/FunctionDeclarationNodeTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Pharborist;
+
+class FunctionDeclarationNodeTest extends \PHPUnit_Framework_TestCase {
+  public function testCloneAsMethodOf() {
+    /** @var \Pharborist\ClassNode $class */
+    $class = Parser::parseSnippet('class Camelot {}');
+    /** @var \Pharborist\FunctionDeclarationNode $func */
+    $func = Parser::parseSnippet('function sing_goofy_song() {}');
+
+    $func->cloneAsMethodOf($class);
+    $this->assertTrue($class->hasMethod('sing_goofy_song'));
+  }
+}


### PR DESCRIPTION
This is a convenience method that would come in very handy for DMU, and probably for other people: the ability to clone a function declaration as a method of an existing class. It's just a convenience method, really, around ClassMethodNode::fromFunction, appending the result to an existing class.

I implemented this with a test, but I had to add a small sanity check to ClassMethodNode::fromFunction in order to get the test to pass, so that's why I'm submitting a PR.
