### PR TITLE
Allow Node::replaceWith() to accept a callable.

### DIFF
--- a/src/Node.php
+++ b/src/Node.php
@@ -268,6 +268,9 @@ abstract class Node implements NodeInterface {
         }
       }
     }
+    elseif (is_callable($nodes)) {
+      $this->replaceWith($nodes($this));
+    }
     else {
       throw new \InvalidArgumentException();
     }

--- a/tests/NodeTest.php
+++ b/tests/NodeTest.php
@@ -336,6 +336,14 @@ class NodeTest extends \PHPUnit_Framework_TestCase {
     $this->createNode('third')->appendTo($parent);
     $second->replaceWith($this->createNode('replacement'));
     $this->assertEquals('replacement', $parent->firstChild()->next()->getText());
+
+    $parent = $this->createParentNode();
+    $original = $this->createNode('original')->appendTo($parent);
+    $original->replaceWith(function(Node $node) use ($original) {
+      $this->assertSame($node, $original);
+      return $this->createNode('replacement');
+    });
+    $this->assertEquals('replacement', $parent->firstChild()->getText());
   }
 
   /**


### PR DESCRIPTION
Issue #44 -- implementing this would mean I could clean up a good chunk of DMU's code, and it's consistent with the jQuery API anyway. I wrote a test and it passes, but I'm not 100% certain I did it right.
