### PR TITLE
Replacement on self is ignored

### DIFF
--- a/src/Node.php
+++ b/src/Node.php
@@ -266,6 +266,9 @@ abstract class Node implements NodeInterface {
       return $this;
     }
     if ($nodes instanceof Node) {
+      if ($nodes === $this) {
+        return $this;
+      }
       $nodes->remove();
       $this->parent->replaceChild($this, $nodes);
     }
@@ -274,13 +277,16 @@ abstract class Node implements NodeInterface {
       $insert_after = NULL;
       /** @var Node $node */
       foreach ($nodes as $node) {
-        $node->remove();
         if ($first) {
-          $this->parent->replaceChild($this, $node);
+          if ($node !== $this) {
+            $node->remove();
+            $this->parent->replaceChild($this, $node);
+          }
           $insert_after = $node;
           $first = FALSE;
         }
         else {
+          $node->remove();
           $insert_after->parent->insertAfterChild($insert_after, $node);
           $insert_after = $node;
         }

--- a/tests/NodeTest.php
+++ b/tests/NodeTest.php
@@ -350,6 +350,39 @@ class NodeTest extends \PHPUnit_Framework_TestCase {
   }
 
   /**
+   * Test replacing a node with itself.
+   */
+  public function testReplaceWithSelf() {
+    $original = $this->createNode('original');
+    $original->replaceWith($original);
+    $this->assertEquals('original', $original->getText());
+  }
+
+  /**
+   * Test replacing a node with collection containing itself.
+   */
+  public function testReplaceWithContainsSelf() {
+    $original = $this->createNode('original');
+    $parent = $this->createParentNode();
+    $original->appendTo($parent);
+
+    // Test replacing with collection only containing node being replaced.
+    $original->replaceWith([$original]);
+    $this->assertEquals('original', $parent->firstChild()->getText());
+
+    // Test replacing with collection that contains node being replaced.
+    $replacements = [
+      $this->createNode('replacement_before'),
+      $original,
+      $this->createNode('replacement_after')
+    ];
+    $original->replaceWith($replacements);
+    $this->assertEquals('replacement_before', $parent->firstChild()->getText());
+    $this->assertEquals('original', $parent->firstChild()->next()->getText());
+    $this->assertEquals('replacement_after', $parent->lastChild()->getText());
+  }
+
+  /**
    * @expectedException \InvalidArgumentException
    */
   public function testInvalidReplaceWith() {


### PR DESCRIPTION
@phenaproxima this patch means

``` php
$node->replaceWith($node);
$node->replaceWith([$node]);
$node->replaceWith([$aNode, $node, $bNode]); // this worked before, just including it for completeness.
```

will now work. If you agree please merge.
