### PR TITLE
Pass the filename when retrieving tokens. Fixes #230.

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -235,7 +235,7 @@ class Parser {
       $tokenizer = new Tokenizer();
       $parser = new self();
     }
-    $tokens = $tokenizer->getAll($source);
+    $tokens = $tokenizer->getAll($source, $filename);
     $parser->filename = $filename;
     return $parser->buildTree(new TokenIterator($tokens));
   }


### PR DESCRIPTION
Fix for #230 
